### PR TITLE
Minor fixes to remote device

### DIFF
--- a/doc/devices/remote.rst
+++ b/doc/devices/remote.rst
@@ -57,7 +57,7 @@ is then converted into a QNode which is placed on the
 .. code-block:: python
 
     @qml.qnode(dev)
-    def quantum_function(theta, x):
+    def quantum_function(theta, phi):
         qml.TwoModeSqueezing(1.0, 0.0, wires=[0,4])
         qml.TwoModeSqueezing(1.0, 0.0, wires=[1,5])
         qml.Beamsplitter(theta, phi, wires=[0,1])

--- a/pennylane_sf/remote.py
+++ b/pennylane_sf/remote.py
@@ -151,12 +151,12 @@ class StrawberryFieldsRemote(StrawberryFieldsSimulator):
     def expval(self, observable, wires, par):
         if observable == "Identity":
             return 1
-        return samples_expectation(self.samples)
+        return samples_expectation(self.samples, modes=self.map_wires(wires))
 
     def var(self, observable, wires, par):
         if observable == "Identity":
             return 0
-        return samples_variance(self.samples)
+        return samples_variance(self.samples, modes=self.map_wires(wires))
 
     def probability(self, wires=None):  # pylint: disable=missing-function-docstring
         all_probs = all_fock_probs_pnr(self.samples)

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -110,7 +110,9 @@ class TestDevice:
         with pytest.raises(ValueError, match="Device has a fixed number of"):
             qml.device("strawberryfields.remote", wires=8, backend="X8", shots=10)
 
-        dev_iterable_wires = qml.device("strawberryfields.remote", wires=range(8), backend="X8", shots=10)
+        dev_iterable_wires = qml.device(
+            "strawberryfields.remote", wires=range(8), backend="X8", shots=10
+        )
         assert dev_iterable_wires.wires == Wires(range(8))
 
         with pytest.raises(ValueError, match="Device has a fixed number of"):
@@ -271,8 +273,9 @@ class TestVariance:
 
         expected_var = 100
 
-        monkeypatch.setattr("pennylane_sf.remote.samples_variance", lambda *args,
-                                                                           **kwargs: expected_var)
+        monkeypatch.setattr(
+            "pennylane_sf.remote.samples_variance", lambda *args, **kwargs: expected_var
+        )
         var = quantum_function(1.0, 0)
 
         assert var == expected_var

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -218,7 +218,7 @@ class TestExpval:
         expected_expval = 100
 
         monkeypatch.setattr(
-            "pennylane_sf.remote.samples_expectation", lambda *args: expected_expval
+            "pennylane_sf.remote.samples_expectation", lambda *args, **kwargs: expected_expval
         )
         a = quantum_function(1.0, 0)
 
@@ -240,6 +240,17 @@ class TestExpval:
 
         assert a == 1
 
+    @pytest.mark.parametrize("mode, expectation", ((0, 2.3), (1, 2.0)))
+    def test_expvals(self, monkeypatch, mode, expectation):
+        """Test that the expectation value is evaluated correctly when applied to MOCK_SAMPLES"""
+        shots = 10
+        monkeypatch.setattr("strawberryfields.RemoteEngine", MockEngine)
+        dev = qml.device("strawberryfields.remote", backend="X8", shots=shots)
+        dev.samples = MOCK_SAMPLES
+        w = dev.wires[mode]
+        result = dev.expval(qml.NumberOperator, w, None)
+        assert np.allclose(result, expectation)
+
 
 class TestVariance:
     """Test that variances are correctly returned from the hardware device."""
@@ -260,7 +271,8 @@ class TestVariance:
 
         expected_var = 100
 
-        monkeypatch.setattr("pennylane_sf.remote.samples_variance", lambda *args: expected_var)
+        monkeypatch.setattr("pennylane_sf.remote.samples_variance", lambda *args,
+                                                                           **kwargs: expected_var)
         var = quantum_function(1.0, 0)
 
         assert var == expected_var
@@ -279,6 +291,17 @@ class TestVariance:
 
         a = quantum_function(1.0, 0)
         assert a == 0
+
+    @pytest.mark.parametrize("mode, var", ((0, 1.61), (1, 1.2)))
+    def test_vars(self, monkeypatch, mode, var):
+        """Test that the variance is evaluated correctly when applied to MOCK_SAMPLES"""
+        shots = 10
+        monkeypatch.setattr("strawberryfields.RemoteEngine", MockEngine)
+        dev = qml.device("strawberryfields.remote", backend="X8", shots=shots)
+        dev.samples = MOCK_SAMPLES
+        w = dev.wires[mode]
+        result = dev.var(qml.NumberOperator, w, None)
+        assert np.allclose(result, var)
 
 
 class TestProbs:

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -162,7 +162,7 @@ class TestWiresIntegrationRemote:
         circuit2 = make_x8_circuit_expval(dev2, wires2)
 
         monkeypatch.setattr(
-            "pennylane_sf.remote.samples_expectation", lambda *args: expected_expval
+            "pennylane_sf.remote.samples_expectation", lambda *args, **kwargs: expected_expval
         )
 
         assert np.allclose(circuit1(1.0, 0), circuit2(1.0, 0), tol)


### PR DESCRIPTION
This PR does the following:

- correct typo in docs
- ensure expval and variances are returning correctly.

Beforehand, for expval I was always getting zero for:
```python
import pennylane as qml

dev = qml.device('strawberryfields.remote', backend="X8", shots=1000, sf_token="...")

@qml.qnode(dev)
def quantum_function(theta, phi):
    qml.TwoModeSqueezing(1.0, 0.0, wires=[0,4])
    qml.TwoModeSqueezing(1.0, 0.0, wires=[1,5])
    qml.Beamsplitter(theta, phi, wires=[0,1])
    qml.Beamsplitter(theta, phi, wires=[4,5])
    return qml.expval(qml.NumberOperator(0))

quantum_function(0.3, 0.4)
```