### PR TITLE
Fix NumPy indexing bug

### DIFF
--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -107,6 +107,7 @@ class StrawberryFieldsSimulator(Device):
 
         # translate to consecutive wires used by device
         device_wires = self.map_wires(wires)
+        par = [p.unwrap() if hasattr(p, "unwrap") else p for p in par]
 
         op = self._operation_map[operation](*sf_par)
         op | [self.q[i] for i in device_wires.labels]  # pylint: disable=pointless-statement
@@ -129,6 +130,7 @@ class StrawberryFieldsSimulator(Device):
         """
         # translate to consecutive wires used by device
         device_wires = self.map_wires(wires)
+        par = [p.unwrap() if hasattr(p, "unwrap") else p for p in par]
 
         # The different "expectation" functions require different inputs,
         # which is at the moment solved by having dummy arguments.
@@ -160,6 +162,7 @@ class StrawberryFieldsSimulator(Device):
         """
         # translate to consecutive wires used by device
         device_wires = self.map_wires(wires)
+        par = [p.unwrap() if hasattr(p, "unwrap") else p for p in par]
 
         # The different "expectation" functions require different inputs,
         # which is at the moment solved by having dummy arguments.

--- a/pennylane_sf/simulator.py
+++ b/pennylane_sf/simulator.py
@@ -107,6 +107,8 @@ class StrawberryFieldsSimulator(Device):
 
         # translate to consecutive wires used by device
         device_wires = self.map_wires(wires)
+
+        # TODO: the following can be removed once tape-mode is the default in PennyLane
         par = [p.unwrap() if hasattr(p, "unwrap") else p for p in par]
 
         op = self._operation_map[operation](*sf_par)
@@ -130,6 +132,7 @@ class StrawberryFieldsSimulator(Device):
         """
         # translate to consecutive wires used by device
         device_wires = self.map_wires(wires)
+        # TODO: the following can be removed once tape-mode is the default in PennyLane
         par = [p.unwrap() if hasattr(p, "unwrap") else p for p in par]
 
         # The different "expectation" functions require different inputs,
@@ -162,6 +165,7 @@ class StrawberryFieldsSimulator(Device):
         """
         # translate to consecutive wires used by device
         device_wires = self.map_wires(wires)
+        # TODO: the following can be removed once tape-mode is the default in PennyLane
         par = [p.unwrap() if hasattr(p, "unwrap") else p for p in par]
 
         # The different "expectation" functions require different inputs,

--- a/tests/test_gbs.py
+++ b/tests/test_gbs.py
@@ -500,7 +500,7 @@ class TestStrawberryFieldsGBS:
 
         assert np.allclose(dev.state.displacement(), np.zeros(4))
         assert np.allclose(dev.state.cov(), target_cov, atol=tol)
-        assert not dev.samples
+        assert dev.samples.size == 0
 
     def test_pre_measure_state_and_samples_non_analytic(self, tol):
         """Test that the pre_measure method operates as expected in non-analytic mode by


### PR DESCRIPTION
A recent change in PennyLane resulted in indexing into NumPy arrays returning array scalars, rather than Python scalars:

```pycon
>>> from pennylane import numpy as np
>>> np.array([1, 2])[0]
array(1)
```

This causes an issue in the Strawberry Fields plugin, since the Hafnian functions provided by The Walrus do not expect scalar array inputs.

To fix this, we make sure that operation parameters are 'unwrapped' by the SF plugin before being sent to SF, by calling `p.unwrap()`.

**Note:** this can be considered a 'hotfix'. Ideally, this unwrapping should be done in PennyLane. However, there are a couple of reasons we don't do this here:

* This issue only affects non-tape mode. In tape mode, PennyLane _already_ unwraps the operation parameters. Once tape-mode is supported by default, this issue will no longer be applicable.

* We cannot do the unwrapping in the parent `Device` class, as there are some devices that might be in autograd passthru mode, and do not want unwrapping to occur.

