### PR TITLE
Add Fock device support for FockDiagonalObservable

### DIFF
--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -249,6 +249,7 @@ def fock_diag_obs(state, device_wires, params):
     )
 
 
+# The following snippet is user contributed
 def diagonal_moments(state, modes, order):
     """Calculates high-order moments of photon number for given input state.
 

--- a/pennylane_sf/fock.py
+++ b/pennylane_sf/fock.py
@@ -64,7 +64,7 @@ from strawberryfields.ops import (
     Interferometer,
 )
 
-from .expectations import identity, mean_photon, number_expectation, homodyne, fock_state, poly_xp
+from .expectations import identity, mean_photon, number_expectation, homodyne, fock_state, poly_xp, fock_diag_obs
 from .simulator import StrawberryFieldsSimulator
 
 
@@ -119,6 +119,7 @@ class StrawberryFieldsFock(StrawberryFieldsSimulator):
         "QuadOperator": homodyne(),
         "PolyXP": poly_xp,
         "FockStateProjector": fock_state,
+        "FockDiagonalObservable": fock_diag_obs,
         "Identity": identity,
     }
 


### PR DESCRIPTION
**Context**

Adds support for the Fock device to `FockDiagonalObservable`. For background description, see https://github.com/PennyLaneAI/pennylane/issues/951 and https://github.com/PennyLaneAI/pennylane/pull/969.