### PR TITLE
Fix tests with tape mode

### DIFF
--- a/doc/devices/gbs.rst
+++ b/doc/devices/gbs.rst
@@ -50,13 +50,13 @@ Hence, QNodes bound to the ``strawberryfields.gbs`` device must consist solely o
 .. code-block:: python
 
     from pennylane_sf.ops import ParamGraphEmbed
-    import numpy as np
+    from pennylane import numpy as np
 
     A = np.array([
         [0.0, 1.0, 1.0, 1.0],
         [1.0, 0.0, 1.0, 0.0],
         [1.0, 1.0, 0.0, 0.0],
-        [1.0, 0.0, 0.0, 0.0]])
+        [1.0, 0.0, 0.0, 0.0]], requires_grad=False)
     n_mean = 2.5
 
     @qml.qnode(dev)
@@ -113,7 +113,7 @@ has shown how to calculate the derivative of the output GBS probability distribu
 
 .. math::
 
-    \partial_{\mathbf{w}} P(\mathbf{n}, \mathbf{w}) = \frac{\mathbf{n} - \langle\mathbf{n}\rangle}{\mathbf{w}}P(\mathbf{n}, \mathbf{w}),,
+    \partial_{\mathbf{w}} P(\mathbf{n}, \mathbf{w}) = \frac{\mathbf{n} - \langle\mathbf{n}\rangle}{\mathbf{w}}P(\mathbf{n}, \mathbf{w}),
 
 where :math:`\mathbf{n}` is a sample given by counting the number of photons observed in each mode.
 

--- a/doc/devices/tf.rst
+++ b/doc/devices/tf.rst
@@ -133,7 +133,7 @@ The Strawberry Fields TF device accepts additional arguments beyond the PennyLan
 Supported operations
 ~~~~~~~~~~~~~~~~~~~~~
 
-The Strawberry Fields Fock device supports all continuous-variable (CV) operations and observables
+The Strawberry Fields TF device supports all continuous-variable (CV) operations and observables
 provided by PennyLane, including both Gaussian and non-Gaussian operations.
 
 **Supported operations:**

--- a/pennylane_sf/gbs.py
+++ b/pennylane_sf/gbs.py
@@ -28,6 +28,7 @@ from thewalrus.quantum import find_scaling_adjacency_matrix as rescale
 from thewalrus.quantum import photon_number_mean_vector
 
 import pennylane as qml
+from pennylane.tape import QuantumTape
 from pennylane.operation import Probability
 from pennylane.wires import Wires
 
@@ -246,7 +247,12 @@ class StrawberryFieldsGBS(StrawberryFieldsSimulator):
     def jacobian(self, *args):
         """Calculates the Jacobian of the device.
 
+        Either takes a single QuantumTape or the operations, observables and
+        variable_deps individually.
+
         Args:
+            tape (.QuantumTape): the tape to get the operations, observables and variable_deps
+                from, instead of passing them individually
             operations (list[~pennylane.operation.Operation]): operations to be applied to the
                 device
             observables (list[~pennylane.operation.Operation]): observables to be measured
@@ -258,6 +264,15 @@ class StrawberryFieldsGBS(StrawberryFieldsSimulator):
             array[float]: Jacobian matrix of size (``len(probs)``, ``num_wires``)
         """
         self.reset()
+
+        not_a_tape = len(args) == 1 and not isinstance(args[0], QuantumTape)
+        wrong_number_of_args = len(args) != 1 and len(args) != 3
+
+        if not_a_tape or wrong_number_of_args:
+            raise TypeError(
+                "Arguments must either contain a single QuantumTape or the operations"
+                "observables and variable_deps."
+            )
 
         if len(args) == 1:
             tape = args[0]

--- a/pennylane_sf/gbs.py
+++ b/pennylane_sf/gbs.py
@@ -261,10 +261,13 @@ class StrawberryFieldsGBS(StrawberryFieldsSimulator):
 
         if len(args) == 1:
             tape = args[0]
-            operations, observables, variable_deps = tape.operations, tape.observables, tape.graph.variable_deps
+            operations, observables, variable_deps = (
+                tape.operations,
+                tape.observables,
+                tape.graph.variable_deps,
+            )
         else:
             operations, observables, variable_deps = args
-
 
         requested_wires = observables[0].wires
 

--- a/pennylane_sf/tf.py
+++ b/pennylane_sf/tf.py
@@ -53,9 +53,7 @@ from strawberryfields.ops import (
     Interferometer,
 )
 
-from pennylane.operation import Operator
 from pennylane.wires import Wires
-from pennylane.variable import Variable
 
 from .expectations import mean_photon, number_expectation, homodyne, poly_xp
 from .simulator import StrawberryFieldsSimulator

--- a/pennylane_sf/tf.py
+++ b/pennylane_sf/tf.py
@@ -142,7 +142,7 @@ class StrawberryFieldsTF(StrawberryFieldsSimulator):
     name = "Strawberry Fields TensorFlow PennyLane plugin"
     short_name = "strawberryfields.tf"
 
-    _capabilities = {"model": "cv", "passthru_interface": "tf", "provides_jacobian": True}
+    _capabilities = {"model": "cv", "passthru_interface": "tf"}
 
     _operation_map = {
         # Cannot yet support catstates, since they still accept complex parameter
@@ -272,80 +272,3 @@ class StrawberryFieldsTF(StrawberryFieldsSimulator):
         ind = np.indices([cutoff] * N).reshape(N, -1).T
         probs = OrderedDict((tuple(k), v) for k, v in zip(ind, probs))
         return probs
-
-    def jacobian(self, queue, observables, parameters):
-        # pylint: disable=missing-function-docstring
-        op_params = {}
-        new_queue = []
-        variables = []
-
-        with tf.GradientTape(persistent=True) as tape:
-            for operation in queue:
-                # Copy the operation parameters to the op_params dictionary.
-                # Note that these are the unwrapped parameters, so PennyLane
-                # free parameters will be represented as Variable instances.
-                op_params[operation] = operation.data[:]
-
-            # Loop through the free parameter reference dictionary
-            for _, par_dep_list in parameters.items():
-                if not par_dep_list:
-                    # parameter is not used within circuit
-                    v = tf.Variable(0, dtype=tf.float64)
-                    variables.append(v)
-                    continue
-
-                # get the first parameter dependency for each free parameter
-                first = par_dep_list[0]
-
-                # For the above parameter dependency, get the corresponding
-                # operation parameter variable, and get the numeric value.
-                # Convert the resulting value to a TensorFlow tensor.
-                val = first.op.data[first.par_idx].val
-                mult = first.op.data[first.par_idx].mult
-                v = tf.Variable(val / mult, dtype=tf.float64)
-
-                # Mark the variable to be watched by the gradient tape,
-                # and append it to the variable list.
-                variables.append(v)
-
-                for p in par_dep_list:
-                    # Replace the existing Variable free parameter in the op_params dictionary
-                    # with the corresponding tf.Variable parameter.
-                    # Note that the free parameter might be scaled by the
-                    # variable.mult scaling factor.
-                    mult = p.op.data[p.par_idx].mult
-                    op_params[p.op][p.par_idx] = v * mult
-
-            # check that no Variables remain in the op_params dictionary
-            values = [item for sublist in op_params.values() for item in sublist]
-            assert not any(
-                isinstance(v, Variable) for v in values
-            ), "A pennylane.Variable instance was not correctly converted to a tf.Variable"
-
-            # flatten the variables list in case of nesting
-            variables = tf.nest.flatten(variables)
-            tape.watch(variables)
-
-            for operation in queue:
-                # Apply each operation, but instead of passing operation.parameters
-                # (which contains the evaluated numeric parameter values),
-                # pass op_params[operation], which contains numeric values
-                # for fixed parameters, and tf.Variable objects for free parameters.
-                try:
-                    # turn off domain checking since PassthruQNode qfuncs can take any class as input
-                    Operator.do_check_domain = False
-                    # generate the new operation
-                    new_op = operation.__class__(*op_params[operation], wires=operation.wires)
-                finally:
-                    Operator.do_check_domain = True
-
-                new_queue.append(new_op)
-
-            self.reset()
-
-            res = self.execute(new_queue, observables, parameters=parameters)
-            res = tf.cast(tf.squeeze(tf.stack(res)), dtype=tf.float64)
-
-        jac = tape.jacobian(res, variables, experimental_use_pfor=False)
-        jac = tf.stack([i if i is not None else tf.zeros(res.shape, dtype=tf.float64) for i in jac])
-        return jac.numpy().T

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 strawberryfields>=0.15
-pennylane>=0.11
+git+https://github.com/PennyLaneAI/pennylane.git
 tensorflow>=2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,9 @@ import pytest
 # defaults
 TOLERANCE = 1e-5
 
+# TODO: remove before merging!
+import pennylane as qml
+qml.enable_tape()
 
 @pytest.fixture
 def tol():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,6 @@ import pytest
 # defaults
 TOLERANCE = 1e-5
 
-# TODO: remove before merging!
-import pennylane as qml
-qml.enable_tape()
 
 @pytest.fixture
 def tol():

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -758,13 +758,16 @@ class TestProbability:
 
         # differentiate with respect to parameter a
         circuit.qtape.trainable_params = {0}
-        res_F = circuit.qtape.jacobian(dev, method="numeric").flat
+        res_F = circuit.qtape.jacobian(dev, method="numeric").flatten()
         expected_gradient = 2 * np.exp(-(a ** 2)) * a ** (2 * n - 1) * (n - a ** 2) / fac(n)
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
+        # re-construct tape to reset trainable_params
+        circuit.construct([a, phi], {})
+
         # differentiate with respect to parameter phi
         circuit.qtape.trainable_params = {1}
-        res_F = circuit.qtape.jacobian(dev, method="numeric").flat
+        res_F = circuit.qtape.jacobian(dev, method="numeric").flatten()
         expected_gradient = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
@@ -790,7 +793,7 @@ class TestProbability:
 
         # differentiate with respect to parameter a
         circuit.qtape.trainable_params = {0}
-        res_F = circuit.qtape.jacobian(dev, method="numeric").flat
+        res_F = circuit.qtape.jacobian(dev, method="numeric").flatten()
         assert res_F.shape == (cutoff,)
 
         expected_gradient = (
@@ -802,9 +805,12 @@ class TestProbability:
         expected_gradient[n % 2 != 0] = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
+        # re-construct tape to reset trainable_params
+        circuit.construct([r, phi], {})
+
         # differentiate with respect to parameter phi
         circuit.qtape.trainable_params = {1}
-        res_F = circuit.qtape.jacobian(dev, method="numeric").flat
+        res_F = circuit.qtape.jacobian(dev, method="numeric").flatten()
         expected_gradient = 0
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
@@ -833,14 +839,14 @@ class TestProbability:
         # get the classical jacobian, since `tape.jacobian` only calculates
         # the quantum jacobian and the reuse of parameters `a` and `phi` in
         # the circuit constitutes classical processing
-        classical_jac = get_classical_jacobian(circuit)(a, phi)
+        classical_jac = np.array([1, 1])
 
         # construct tape
         circuit.construct([a, phi], {})
 
         # differentiate with respect to parameter a
-        circuit.qtape.trainable_params = {0}
-        res_F = circuit.qtape.jacobian(dev, method="numeric").flat
+        circuit.qtape.trainable_params = {0, 2}
+        res_F = circuit.qtape.jacobian(dev, method="numeric")
         expected_gradient = (
             2
             * (a ** (-1 + 2 * n0 + 2 * n1))
@@ -850,11 +856,14 @@ class TestProbability:
         )
         assert np.allclose(res_F @ classical_jac, expected_gradient, atol=tol, rtol=0)
 
+        # re-construct tape to reset trainable_params
+        circuit.construct([a, phi], {})
+
         # differentiate with respect to parameter phi
-        circuit.qtape.trainable_params = {1}
-        res_F = circuit.qtape.jacobian(dev, method="numeric").flat
+        circuit.qtape.trainable_params = {1, 3}
+        res_F = circuit.qtape.jacobian(dev, method="numeric")
         expected_gradient = 0
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res_F @ np.array([1, 1]), expected_gradient, atol=tol, rtol=0)
 
     def test_analytic_diff_error(self, tol):
         """Test that the analytic gradients are not supported when returning
@@ -875,7 +884,7 @@ class TestProbability:
         circuit.construct([a, phi], {})
 
         with pytest.raises(ValueError, match="The analytic gradient method cannot be used"):
-            _ = circuit.qtape.jacobian(dev, method="analytic").flat
+            _ = circuit.qtape.jacobian(dev, method="analytic").flatten()
 
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -611,17 +611,14 @@ class TestVariance:
         expected = np.exp(2 * r) * np.sin(phi) ** 2 + np.exp(-2 * r) * np.cos(phi) ** 2
         assert np.allclose(var, expected, atol=tol, rtol=0)
 
-        # circuit jacobians
-        gradA = circuit.jacobian([r, phi], method="A")
-        gradF = circuit.jacobian([r, phi], method="F")
+        grad = qml.jacobian(circuit)(r, phi)
         expected = np.array(
             [
                 2 * np.exp(2 * r) * np.sin(phi) ** 2 - 2 * np.exp(-2 * r) * np.cos(phi) ** 2,
                 2 * np.sinh(2 * r) * np.sin(2 * phi),
             ]
         )
-        assert np.allclose(gradA, expected, atol=tol, rtol=0)
-        assert np.allclose(gradF, expected, atol=tol, rtol=0)
+        assert np.allclose(grad, expected, atol=tol, rtol=0)
 
     def test_second_order_cv(self, tol):
         """Test variance of a second order CV expectation value"""
@@ -640,10 +637,9 @@ class TestVariance:
         expected = n ** 2 + n + np.abs(a) ** 2 * (1 + 2 * n)
         assert np.allclose(var, expected, atol=tol, rtol=0)
 
-        # circuit jacobians
-        gradF = circuit.jacobian([n, a], method="F")
+        grad = qml.jacobian(circuit)(n, a)
         expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
-        assert np.allclose(gradF, expected, atol=tol, rtol=0)
+        assert np.allclose(grad, expected, atol=tol, rtol=0)
 
     def test_polyxp_variance(self, tol):
         """Tests that variance for PolyXP measurement works"""
@@ -746,14 +742,14 @@ class TestProbability:
         n = np.arange(cutoff)
 
         # differentiate with respect to parameter a
-        res_F = circuit.jacobian([a, phi], wrt={0}, method="F").flat
+        res = qml.jacobian(circuit, argnum=0)(a, phi).flat
         expected_gradient = 2 * np.exp(-(a ** 2)) * a ** (2 * n - 1) * (n - a ** 2) / fac(n)
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to parameter phi
-        res_F = circuit.jacobian([a, phi], wrt={1}, method="F").flat
+        res = qml.jacobian(circuit, argnum=1)(a, phi).flat
         expected_gradient = 0
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
     def test_finite_diff_squeezed(self, tol):
         """Test that the jacobian of the probability for a squeezed states is
@@ -772,9 +768,10 @@ class TestProbability:
 
         n = np.arange(cutoff)
 
+
         # differentiate with respect to parameter r
-        res_F = circuit.jacobian([r, phi], wrt={0}, method="F").flatten()
-        assert res_F.shape == (cutoff,)
+        res = qml.jacobian(circuit, argnum=0)(r, phi).flatten()
+        assert res.shape == (cutoff,)
 
         expected_gradient = (
             np.abs(np.tanh(r)) ** n
@@ -783,12 +780,12 @@ class TestProbability:
             / (2 ** (n + 1) * np.cosh(r) ** 2 * np.sinh(r) * fac(n / 2) ** 2)
         )
         expected_gradient[n % 2 != 0] = 0
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to parameter phi
-        res_F = circuit.jacobian([r, phi], wrt={1}, method="F").flat
+        res = qml.jacobian(circuit, argnum=1)(r, phi).flat
         expected_gradient = 0
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
     def test_finite_diff_coherent_two_wires(self, tol):
         """Test that the jacobian of the probability for a coherent states on
@@ -813,7 +810,7 @@ class TestProbability:
         n1 = n1.flatten()
 
         # differentiate with respect to parameter a
-        res_F = circuit.jacobian([a, phi], wrt={0}, method="F").flat
+        res = qml.jacobian(circuit, argnum=0)(a, phi).flat
         expected_gradient = (
             2
             * (a ** (-1 + 2 * n0 + 2 * n1))
@@ -821,12 +818,12 @@ class TestProbability:
             * (-2 * a ** 2 + n0 + n1)
             / (fac(n0) * fac(n1))
         )
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to parameter phi
-        res_F = circuit.jacobian([a, phi], wrt={1}, method="F").flat
+        res = qml.jacobian(circuit, argnum=1)(a, phi).flat
         expected_gradient = 0
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
     def test_analytic_diff_error(self, tol):
         """Test that the analytic gradients are not supported when returning
@@ -842,8 +839,9 @@ class TestProbability:
 
         a = 0.4
         phi = -0.12
+        circuit(a, phi)
         with pytest.raises(ValueError, match="The analytic gradient method cannot be used"):
-            res_F = circuit.jacobian([a, phi], wrt={0}, method="A").flat
+            _ = circuit.qtape.jacobian(dev, method="analytic").flat
 
     def test_tensorn_one_mode_is_mean_photon(self, tol):
         """Test variance of TensorN for a single mode, which resorts to
@@ -870,6 +868,6 @@ class TestProbability:
         assert np.allclose(var, expected, atol=tol, rtol=0)
 
         # circuit jacobians
-        gradF = circuit.jacobian([n, a], method="F")
+        grad = qml.jacobian(circuit)(n, a)
         expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
-        assert np.allclose(gradF, expected, atol=tol, rtol=0)
+        assert np.allclose(grad, expected, atol=tol, rtol=0)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -780,8 +780,8 @@ class TestProbability:
         assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
     def test_finite_diff_coherent_two_wires(self, tol):
-        """Test that the jacobian of the probability for a coherent states is
-        approximated well with finite differences"""
+        """Test that the jacobian of the probability for a coherent states is approximated well with
+        finite differences"""
         cutoff = 4
 
         dev = qml.device("strawberryfields.gaussian", wires=2, cutoff_dim=cutoff)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -57,16 +57,6 @@ unsupported_one_mode_single_real_parameter_gates = [
 ]
 
 
-def get_classical_jacobian(qnode):
-    def classical_preprocessing(*args, **kwargs):
-        """Returns the trainable gate parameters for
-        a given QNode input"""
-        qnode.construct(args, kwargs)
-        return qml.math.stack(qnode.qtape.get_parameters())
-
-    return qml.jacobian(classical_preprocessing)
-
-
 # compare to reference SF engine
 def SF_gate_reference(sf_op, wires, *args):
     """SF reference circuit for gate tests"""
@@ -794,16 +784,16 @@ class TestProbability:
         approximated well with finite differences"""
         cutoff = 4
 
-        dev = qml.device("strawberryfields.fock", wires=2, cutoff_dim=cutoff)
+        dev = qml.device("strawberryfields.gaussian", wires=2, cutoff_dim=cutoff)
 
-        @qml.qnode(dev)
+        @qml.qnode(dev, diff_method="finite-diff")
         def circuit(a, phi):
             qml.Displacement(a, phi, wires=0)
             qml.Displacement(a, phi, wires=1)
             return qml.probs(wires=[0, 1])
 
-        a = 0.4
-        phi = -0.12
+        a = np.array(0.4, requires_grad=True)
+        phi = np.array(-0.12, requires_grad=False)
 
         c = np.arange(cutoff)
         d = np.arange(cutoff)
@@ -811,17 +801,8 @@ class TestProbability:
         n0 = n0.flatten()
         n1 = n1.flatten()
 
-        # get the classical jacobian, since `tape.jacobian` only calculates
-        # the quantum jacobian and the reuse of parameters `a` and `phi` in
-        # the circuit constitutes classical processing
-        classical_jac = np.array([1, 1])
-
-        # construct tape
-        circuit.construct([a, phi], {})
-
         # differentiate with respect to parameter a
-        circuit.qtape.trainable_params = {0, 2}
-        res_F = circuit.qtape.jacobian(dev, method="numeric")
+        res_F = qml.jacobian(circuit)(a, phi)
         expected_gradient = (
             2
             * (a ** (-1 + 2 * n0 + 2 * n1))
@@ -829,16 +810,15 @@ class TestProbability:
             * (-2 * a ** 2 + n0 + n1)
             / (fac(n0) * fac(n1))
         )
-        assert np.allclose(res_F @ classical_jac, expected_gradient, atol=tol, rtol=0)
-
-        # re-construct tape to reset trainable_params
-        circuit.construct([a, phi], {})
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to parameter phi
-        circuit.qtape.trainable_params = {1, 3}
-        res_F = circuit.qtape.jacobian(dev, method="numeric")
+        a = np.array(0.4, requires_grad=False)
+        phi = np.array(-0.12, requires_grad=True)
+
+        res_F = qml.jacobian(circuit)(a, phi)
         expected_gradient = 0
-        assert np.allclose(res_F @ np.array([1, 1]), expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
 
     def test_analytic_diff_error(self, tol):
         """Test that the analytic gradients are not supported when returning

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -285,7 +285,7 @@ class TestExpval:
         monkeypatch.setattr("strawberryfields.RemoteEngine", MockEngine)
         dev = qml.device("strawberryfields.remote", backend="X8", shots=shots)
         dev.samples = MOCK_SAMPLES
-        w = dev.wires[mode]
+        w = Wires(dev.wires[mode])
         result = dev.expval(qml.NumberOperator, w, None)
         assert np.allclose(result, expectation)
 
@@ -338,7 +338,7 @@ class TestVariance:
         monkeypatch.setattr("strawberryfields.RemoteEngine", MockEngine)
         dev = qml.device("strawberryfields.remote", backend="X8", shots=shots)
         dev.samples = MOCK_SAMPLES
-        w = dev.wires[mode]
+        w = Wires(dev.wires[mode])
         result = dev.var(qml.NumberOperator, w, None)
         assert np.allclose(result, var)
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -65,7 +65,7 @@ def disp_sq_circuit(dev):
     """Quantum node for a displaced squeezed circuit"""
 
     @qml.qnode(dev)
-    def circuit(pars):
+    def circuit(*pars):
         qml.Squeezing(pars[0], pars[1], wires=0)
         qml.Displacement(pars[2], pars[3], wires=0)
         qml.Squeezing(pars[4], pars[5], wires=1)
@@ -135,7 +135,7 @@ class TestVarianceDisplacedSqueezed:
             )
             return squared_term
 
-        var = disp_sq_circuit(pars)
+        var = disp_sq_circuit(*pars)
 
         n0 = np.sinh(rs0) ** 2 + np.abs(alpha0) ** 2
         n1 = np.sinh(rs1) ** 2 + np.abs(alpha1) ** 2
@@ -192,12 +192,12 @@ class TestVarianceDisplacedSqueezed:
             )
 
         # differentiate wrt r of the first squeezing operation (rs0)
-        grad = qml.jacobian(disp_sq_circuit, argnum=0)(pars)
+        grad = qml.jacobian(disp_sq_circuit, argnum=0)(*pars)
         expected_gradient = pd_sr(*pars)
         assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
 
         # differentiate wrt r of the second squeezing operation (rs1)
-        grad = qml.jacobian(disp_sq_circuit, argnum=4)(pars)
+        grad = qml.jacobian(disp_sq_circuit, argnum=4)(*pars)
 
         #
         expected_gradient = pd_sr(*reverted_pars)
@@ -246,12 +246,12 @@ class TestVarianceDisplacedSqueezed:
             )
 
         # differentiate with respect to r of the first displacement operation (rd0)
-        grad = qml.jacobian(disp_sq_circuit, argnum=2)(pars)
+        grad = qml.jacobian(disp_sq_circuit, argnum=2)(*pars)
         expected_gradient = pd_dr(*pars)
         assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to r of the second squeezing operation (rd1)
-        grad = qml.jacobian(disp_sq_circuit, argnum=6)(pars)
+        grad = qml.jacobian(disp_sq_circuit, argnum=6)(*pars)
 
         expected_gradient = pd_dr(*reverted_pars)
         assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -50,14 +50,14 @@ class TestVariance:
         assert np.allclose(var, expected, atol=tol, rtol=0)
 
         # differentiate with respect to parameter a
-        res_F = circuit.jacobian([a, phi], wrt={0}, method="F").flat
+        res = qml.jacobian(circuit, argnum=0)(a, phi).flat
         expected_gradient = 4 * (a ** 3 + 3 * a ** 5)
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to parameter phi
-        res_F = circuit.jacobian([a, phi], wrt={1}, method="F").flat
+        res = qml.jacobian(circuit, argnum=1)(a, phi).flat
         expected_gradient = 0
-        assert np.allclose(res_F, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(res, expected_gradient, atol=tol, rtol=0)
 
 
 @pytest.fixture(scope="function")
@@ -192,16 +192,16 @@ class TestVarianceDisplacedSqueezed:
             )
 
         # differentiate wrt r of the first squeezing operation (rs0)
-        gradF = disp_sq_circuit.jacobian([pars], wrt={0}, method="F")
+        grad = qml.jacobian(disp_sq_circuit, argnum=0)(pars)
         expected_gradient = pd_sr(*pars)
-        assert np.allclose(gradF, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
 
         # differentiate wrt r of the second squeezing operation (rs1)
-        gradF = disp_sq_circuit.jacobian([pars], wrt={4}, method="F")
+        grad = qml.jacobian(disp_sq_circuit, argnum=4)(pars)
 
         #
         expected_gradient = pd_sr(*reverted_pars)
-        assert np.allclose(gradF, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
 
     @pytest.mark.parametrize("dev", dev_list)
     def test_tensor_number_displaced_squeezed_pd_displacement(
@@ -209,7 +209,7 @@ class TestVarianceDisplacedSqueezed:
     ):
         """Test the variance of the TensorN observable for a squeezed displaced
         state
-        
+
         The analytic expression for the partial derivate wrt r of the second
         displacement operation can be obtained by passing the parameters of
         operations acting on the second mode first (using reverted_pars).
@@ -246,12 +246,12 @@ class TestVarianceDisplacedSqueezed:
             )
 
         # differentiate with respect to r of the first displacement operation (rd0)
-        gradF = disp_sq_circuit.jacobian([pars], wrt={2}, method="F")
+        grad = qml.jacobian(disp_sq_circuit, argnum=2)(pars)
         expected_gradient = pd_dr(*pars)
-        assert np.allclose(gradF, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
 
         # differentiate with respect to r of the second squeezing operation (rd1)
-        gradF = disp_sq_circuit.jacobian([pars], wrt={6}, method="F")
+        grad = qml.jacobian(disp_sq_circuit, argnum=6)(pars)
 
         expected_gradient = pd_dr(*reverted_pars)
-        assert np.allclose(gradF, expected_gradient, atol=tol, rtol=0)
+        assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)

--- a/tests/test_tf.py
+++ b/tests/test_tf.py
@@ -109,12 +109,10 @@ class TestTF:
 
         @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x):
-            qml.Displacement(x, 0, wires=0)
+            qml.Displacement(x, 0., wires=0)
             return qml.expval(qml.NumberOperator(0))
 
-        assert isinstance(circuit, qml.qnodes.PassthruQNode)
-
-        res = circuit(1)
+        res = circuit(1.)
         assert isinstance(res, tf.Tensor)
         assert np.allclose(res, 1, atol=tol, rtol=0)
 
@@ -123,7 +121,7 @@ class TestTF:
         shots = 10 ** 2
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=10, shots=shots, analytic=False)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
             return qml.expval(qml.NumberOperator(0))
@@ -159,7 +157,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -186,7 +184,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -213,7 +211,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -244,7 +242,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -273,7 +271,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -298,7 +296,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -324,7 +322,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -350,7 +348,7 @@ class TestGates:
 
         assert dev.supports_operation(gate_name)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
             operation(*args, wires=wires)
@@ -379,7 +377,7 @@ class TestExpectation:
         sf_expectation = dev._observable_map[gate_name]
         wires = [0]
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.Displacement(0.1, 0, wires=0)
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
@@ -403,7 +401,7 @@ class TestExpectation:
         sf_expectation = dev._observable_map[gate_name]
         wires = [0, 1]
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit():
             qml.Displacement(0.1, 0, wires=0)
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
@@ -427,7 +425,7 @@ class TestExpectation:
         sf_expectation = dev._observable_map[gate_name]
         wires = [0]
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.Displacement(0.1, 0, wires=0)
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
@@ -452,7 +450,7 @@ class TestExpectation:
         sf_expectation = dev._observable_map[gate_name]
         wires = [0]
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(*args):
             qml.Displacement(0.1, 0, wires=0)
             qml.TwoModeSqueezing(0.1, 0, wires=[0, 1])
@@ -475,7 +473,7 @@ class TestExpectation:
         dev = qml.device("strawberryfields.tf", wires=1, hbar=hbar, cutoff_dim=cutoff_dim)
         Q = np.array([0, 1, 0])  # x expectation
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
             return qml.expval(qml.PolyXP(Q, 0))
@@ -485,7 +483,7 @@ class TestExpectation:
 
         Q = np.diag([-0.5, 1 / (2 * hbar), 1 / (2 * hbar)])  # mean photon number
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x):
             qml.ThermalState(nbar, wires=0)
             qml.Displacement(x, 0, wires=0)
@@ -504,7 +502,7 @@ class TestExpectation:
         dev = qml.device("strawberryfields.tf", wires=2, hbar=hbar, cutoff_dim=cutoff_dim)
 
         # test correct number state expectation |<n|a>|^2
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x):
             qml.Displacement(x, 0, wires=0)
             return qml.expval(qml.FockStateProjector(np.array([2]), wires=0))
@@ -513,7 +511,7 @@ class TestExpectation:
         assert np.allclose(circuit(a), expected, atol=tol, rtol=0)
 
         # test correct number state expectation |<n|S(r)>|^2
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x):
             qml.Squeezing(x, 0, wires=0)
             return qml.expval(qml.FockStateProjector(np.array([2, 0]), wires=[0, 1]))
@@ -530,7 +528,7 @@ class TestExpectation:
         hbar = 2
         dev = qml.device("strawberryfields.tf", wires=2, hbar=hbar, cutoff_dim=cutoff_dim)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x, y):
             qml.Squeezing(x, 0, wires=0)
             qml.Squeezing(y, 0, wires=1)
@@ -561,7 +559,7 @@ class TestExpectation:
         hbar = 2
         dev = qml.device("strawberryfields.tf", wires=2, hbar=hbar, cutoff_dim=cutoff_dim)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(x, y):
             qml.Squeezing(x, 0, wires=0)
             qml.Squeezing(y, 0, wires=1)
@@ -577,7 +575,7 @@ class TestVariance:
         """Test variance of a first order CV expectation value"""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(r, phi):
             qml.Squeezing(r, 0, wires=0)
             qml.Rotation(phi, wires=0)
@@ -598,7 +596,7 @@ class TestVariance:
         """Test variance of a second order CV expectation value"""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(n, a):
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
@@ -617,7 +615,7 @@ class TestVariance:
         """Tests that variance for PolyXP measurement works"""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(r, phi):
             qml.Squeezing(r, 0, wires=0)
             qml.Rotation(phi, wires=0)
@@ -639,7 +637,7 @@ class TestProbability:
         cutoff = 10
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a, phi):
             qml.Displacement(a, phi, wires=0)
             return qml.probs(wires=0)
@@ -659,7 +657,7 @@ class TestProbability:
         cutoff = 10
         dev = qml.device("strawberryfields.tf", wires=2, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a, phi):
             qml.Displacement(a, phi, wires=0)
             qml.Displacement(a, phi, wires=1)
@@ -681,7 +679,7 @@ class TestProbability:
         cutoff = 10
         dev = qml.device("strawberryfields.tf", wires=2, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a, phi):
             qml.Displacement(a, phi, wires=1)
             return qml.probs(wires=1)
@@ -707,7 +705,7 @@ class TestPassthruGradients:
 
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a, phi):
             qml.Displacement(a, phi, wires=0)
             return qml.probs(wires=[0])
@@ -737,7 +735,7 @@ class TestPassthruGradients:
 
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(r, phi):
             qml.Squeezing(r, phi, wires=0)
             return qml.probs(wires=[0])
@@ -752,7 +750,7 @@ class TestPassthruGradients:
 
         # differentiate with respect to parameter r
         grad = tape.jacobian(res, r)
-        assert grad.shape == (1, cutoff)
+        assert grad.shape == (cutoff,)
 
         expected_gradient = (
             np.abs(tf.math.tanh(r)) ** n
@@ -776,7 +774,7 @@ class TestPassthruGradients:
 
         dev = qml.device("strawberryfields.tf", wires=2, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a, phi):
             qml.Displacement(a, phi, wires=0)
             qml.Displacement(a, phi, wires=1)
@@ -820,7 +818,7 @@ class TestPassthruGradients:
         # NumberOperator
         assert isinstance(op, qml.NumberOperator)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(n, a):
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
@@ -841,7 +839,7 @@ class TestPassthruGradients:
         """Test gradient of the photon variance of a squeezed state"""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(r, phi):
             qml.Squeezing(r, 0, wires=0)
             qml.Rotation(phi, wires=0)
@@ -868,7 +866,7 @@ class TestPassthruGradients:
         """Test variance of a second order CV variance"""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(n, a):
             qml.ThermalState(n, wires=0)
             qml.Displacement(a, 0, wires=0)
@@ -893,7 +891,7 @@ class TestPassthruGradients:
         state vector is correct."""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a):
             qml.Displacement(a, 0, wires=0)
             return qml.expval(qml.Identity(0))
@@ -916,7 +914,7 @@ class TestPassthruGradients:
         density matrix is correct."""
         dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(a):
             qml.Displacement(a, 0, wires=0)
             return qml.expval(qml.Identity(0))
@@ -940,7 +938,7 @@ class TestPassthruGradients:
         cutoff = 15
         dev = qml.device("strawberryfields.tf", wires=2, cutoff_dim=cutoff)
 
-        @qml.qnode(dev, interface="tf", method="backprop")
+        @qml.qnode(dev, interface="tf", diff_method="backprop")
         def circuit(r, phi, input_state, output_state):
             qml.FockStateVector(input_state, wires=[0, 1])
             qml.TwoModeSqueezing(r, phi, wires=[0, 1])
@@ -969,102 +967,6 @@ class TestPassthruGradients:
             r_grad, 2 * (np.sinh(R) - np.sinh(R) ** 3) / np.cosh(R) ** 5, atol=tol, rtol=0
         )
         assert np.allclose(phi_grad, 0.0, atol=tol, rtol=0)
-
-
-class TestDeviceGradients:
-    """Test various gradients working correctly with the device diff method"""
-
-    def test_gradient_coherent(self, tol):
-        """Test that the jacobian of the probability for a coherent states is
-        approximated well with finite differences"""
-        cutoff = 10
-
-        dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=cutoff)
-
-        @qml.qnode(dev, interface="autograd", method="device")
-        def circuit(a, phi):
-            qml.Displacement(a, phi, wires=0)
-            return qml.probs(wires=[0])
-
-        a = qml.numpy.array(0.4, requires_grad=True)
-        phi = qml.numpy.array(-0.12, requires_grad=True)
-
-        n = np.arange(cutoff)
-
-        grad = qml.jacobian(circuit)(a, phi)
-        expected_gradient = np.zeros_like(grad)
-        expected_gradient[:, 0] = 2 * np.exp(-(a ** 2)) * a ** (2 * n - 1) * (n - a ** 2) / fac(n)
-        assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
-
-    def test_gradient_squeezed(self, tol):
-        """Test that the jacobian of the probability for a squeezed states is
-        approximated well with finite differences"""
-        cutoff = 5
-
-        dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=cutoff)
-
-        @qml.qnode(dev, interface="autograd", method="device")
-        def circuit(r, phi):
-            qml.Squeezing(r, phi, wires=0)
-            return qml.probs(wires=[0])
-
-        r = qml.numpy.array(0.4, requires_grad=True)
-        phi = qml.numpy.array(-0.12, requires_grad=True)
-
-        n = np.arange(cutoff)
-
-        # differentiate with respect to parameter r
-        grad = qml.jacobian(circuit)(r, phi)
-        assert grad.shape == (cutoff, 2)
-
-        expected_gradient = (
-            np.abs(np.tanh(r)) ** n
-            * (1 + 2 * n - np.cosh(2 * r))
-            * fac(n)
-            / (2 ** (n + 1) * np.cosh(r) ** 2 * np.sinh(r) * fac(n / 2) ** 2)
-        )
-        expected_gradient[n % 2 != 0] = 0
-        expected_gradient = np.vstack([expected_gradient, np.zeros([cutoff])]).T
-        assert np.allclose(grad, expected_gradient, atol=tol, rtol=0)
-
-    def test_gradient_second_order_cv(self, tol):
-        """Test gradient of a second order CV variance"""
-        dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
-
-        @qml.qnode(dev, interface="autograd", method="device")
-        def circuit(weights):
-            qml.ThermalState(weights[0], wires=0)
-            qml.Displacement(weights[1], 0, wires=0)
-            return qml.var(qml.NumberOperator(0))
-
-        n = 0.12
-        a = 0.105
-        weights = qml.numpy.array([n, a], requires_grad=True)
-
-        # circuit jacobians
-        grad = qml.grad(circuit)(weights)
-        expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1)])
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
-
-    def test_parameter_not_used_in_circuit(self, tol):
-        """Test gradient of a second order CV variance. Also check 0 is returned
-        for gradient of parameter not used in circuit"""
-        dev = qml.device("strawberryfields.tf", wires=1, cutoff_dim=15)
-
-        @qml.qnode(dev, interface="autograd", method="device")
-        def circuit(weights):
-            qml.ThermalState(weights[0], wires=0)
-            qml.Displacement(weights[1], 0, wires=0)
-            return qml.var(qml.NumberOperator(0))
-
-        n = 0.12
-        a = 0.105
-        weights = qml.numpy.array([n, a, 0.543], requires_grad=True)
-
-        # circuit jacobians
-        grad = qml.grad(circuit)(weights)
-        expected = np.array([2 * a ** 2 + 2 * n + 1, 2 * a * (2 * n + 1), 0])
-        assert np.allclose(grad, expected, atol=tol, rtol=0)
 
 
 class TestHighLevelIntegration:


### PR DESCRIPTION
**Description of the Change:**
The tests are failing when enabling tape mode. The main thing changed is that `circuit.jacobian` is removed in favour of `qml.jacobian`.

Some issues that still aren't solved when enabling tape mode (that pass without):
* SF seems to support state preparation operations applied _after_ other operations (e.g. a two-mode sqeezing gate on `wires=[0, 1]` followed by a `FockStateVector` on `wires=0`). This causes an error in tape mode.
* Calculate the derivative of the `TensorN` operation causes an `IndexError: tuple index out of range` in autograd.
* Calculating the derivative of `ParamGraphEmbed` doesn't seem to work either.

**Benefits:**
The PennyLane-SF tests can pass in tape mode.

**Possible Drawbacks:**
Since I'm using `qml.jacobian` (instead of e.g. `circuit.qtape.jacobian`) the differentiation method cannot be chosen; thus it is currently always the default one used.

**Related GitHub Issues:**
Potentially related to some breaking demos which are using PennyLane-SF.
