### PR TITLE
Update `requirements.txt` and `setup.py` to have no branch pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 strawberryfields>=0.15
-git+git://github.com/PennyLaneAI/pennylane@master
+git+git://github.com/PennyLaneAI/pennylane
 tensorflow>=2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.15",
-    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git@master"
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git"
 ]
 
 info = {


### PR DESCRIPTION
**Context**

`pip` is sensitive to the specific branch of a project that is being installed. Therefore, if non-matching branches are installed for the same package, a dependency conflict can arise.

This happens even when the branch that is installed is the `master` branch.

This behaviour can cause issues with the QML repo checks (e.g., [here](https://github.com/PennyLaneAI/qml/runs/3848839795?check_suite_focus=true#step:7:266)).

**Changes**

Removes the pinning to the `master` branch in related files. The branch that will be pulled will remain to be the `master` branch and `pip` should also have no issues with dependencies.