### PR TITLE
fixed tests requiring gradients

### DIFF
--- a/pennylane_sf/expectations.py
+++ b/pennylane_sf/expectations.py
@@ -68,9 +68,9 @@ def identity(state, device_wires, params):
 
     # construct the standard 2D density matrix, and take the trace
     new_ax = np.arange(2 * N).reshape([N, 2]).T.flatten()
-    tr = np.trace(dm.transpose(new_ax).reshape([D ** N, D ** N])).real
+    tr = np.trace(dm.transpose(new_ax).reshape([D**N, D**N])).real
 
-    return tr, tr - tr ** 2
+    return tr, tr - tr**2
 
 
 def mean_photon(state, device_wires, params):
@@ -125,7 +125,7 @@ def fock_state(state, device_wires, params):
     if N == len(device_wires):
         # expectation value of the entire system
         ex = state.fock_prob(n)
-        return ex, ex - ex ** 2
+        return ex, ex - ex**2
 
     # otherwise, we must trace out remaining systems.
     if isinstance(state, BaseFockState):
@@ -145,7 +145,7 @@ def fock_state(state, device_wires, params):
         new_state = BaseGaussianState((mu, cov), len(device_wires))
         ex = new_state.fock_prob(n)
 
-    var = ex - ex ** 2
+    var = ex - ex**2
     return ex, var
 
 

--- a/pennylane_sf/gbs.py
+++ b/pennylane_sf/gbs.py
@@ -116,7 +116,7 @@ class StrawberryFieldsGBS(StrawberryFieldsSimulator):
         if not all(singular_values < 1):
             raise ValueError("Singular values of matrix A must be less than 1")
 
-        return np.sum(singular_values ** 2 / (1 - singular_values ** 2))
+        return np.sum(singular_values**2 / (1 - singular_values**2))
 
     # pylint: disable=missing-function-docstring
     def execute(self, queue, observables, parameters=None, **kwargs):
@@ -202,7 +202,7 @@ class StrawberryFieldsGBS(StrawberryFieldsSimulator):
         Returns:
             array: the traced-over array
         """
-        trailing = int(array.size / self.cutoff ** self.num_wires)
+        trailing = int(array.size / self.cutoff**self.num_wires)
 
         array = array.reshape([self.cutoff] * self.num_wires + [trailing])
 

--- a/pennylane_sf/tf.py
+++ b/pennylane_sf/tf.py
@@ -78,7 +78,7 @@ def identity(state, device_wires, params):
     if N == len(device_wires):
         # trace of the entire system
         tr = state.trace()
-        return tr, tr - tr ** 2
+        return tr, tr - tr**2
 
     # get the reduced density matrix
     N = len(device_wires)
@@ -86,9 +86,9 @@ def identity(state, device_wires, params):
 
     # construct the standard 2D density matrix, and take the trace
     new_ax = np.arange(2 * N).reshape([N, 2]).T.flatten()
-    tr = tf.math.real(tf.linalg.trace(tf.reshape(tf.transpose(dm, new_ax), [D ** N, D ** N])))
+    tr = tf.math.real(tf.linalg.trace(tf.reshape(tf.transpose(dm, new_ax), [D**N, D**N])))
 
-    return tr, tr - tr ** 2
+    return tr, tr - tr**2
 
 
 def fock_state(state, device_wires, params):
@@ -110,12 +110,12 @@ def fock_state(state, device_wires, params):
     if N == len(device_wires):
         # expectation value of the entire system
         ex = state.fock_prob(n)
-        return ex, ex - ex ** 2
+        return ex, ex - ex**2
 
     dm = state.reduced_dm(modes=device_wires.tolist())
     ex = tf.math.real(dm[tuple(n[i // 2] for i in range(len(n) * 2))])
 
-    var = ex - ex ** 2
+    var = ex - ex**2
     return ex, var
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 strawberryfields>=0.20.0
-pennylane>=0.19
+https://github.com/PennyLaneAI/pennylane
 tensorflow>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 strawberryfields>=0.20.0
-https://github.com/PennyLaneAI/pennylane
+git+https://github.com/PennyLaneAI/pennylane
 tensorflow>=2.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.20",
-    "https://github.com/PennyLaneAI/pennylane"
+    "git+https://github.com/PennyLaneAI/pennylane"
 ]
 
 info = {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.20",
-    "pennylane @ https://github.com/PennyLaneAI/pennylane"
+    "pennylane @ https://github.com/PennyLaneAI/pennylane.git"
 ]
 
 info = {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.20",
-    "git+https://github.com/PennyLaneAI/pennylane"
+    "pennylane @ https://github.com/PennyLaneAI/pennylane"
 ]
 
 info = {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.20",
-    "pennylane @ https://github.com/PennyLaneAI/pennylane.git"
+    "pennylane @ git+https://github.com/PennyLaneAI/pennylane.git"
 ]
 
 info = {

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("pennylane_sf/_version.py") as f:
 
 requirements = [
     "strawberryfields>=0.20",
-    "pennylane>=0.19"
+    "https://github.com/PennyLaneAI/pennylane"
 ]
 
 info = {

--- a/tests/test_fock.py
+++ b/tests/test_fock.py
@@ -632,8 +632,8 @@ class TestVariance:
             qml.Displacement(a, 0, wires=0)
             return qml.var(qml.NumberOperator(0))
 
-        n = 0.12
-        a = 0.105
+        n = np.array(0.12, requires_grad=True)
+        a = np.array(0.105, requires_grad=True)
 
         var = circuit(n, a)
         expected = n ** 2 + n + np.abs(a) ** 2 * (1 + 2 * n)
@@ -858,8 +858,8 @@ class TestProbability:
             qml.Displacement(a, phi, wires=0)
             return qml.probs(wires=[0])
 
-        a = 0.4
-        phi = -0.12
+        a = np.array(0.4, requires_grad=True)
+        phi = np.array(-0.12, requires_grad=True)
 
         # construct tape
         circuit.construct([a, phi], {})
@@ -884,8 +884,8 @@ class TestProbability:
             qml.Displacement(a, 0, wires=0)
             return qml.var(op)
 
-        n = 0.12
-        a = 0.105
+        n = np.array(0.12, requires_grad=True)
+        a = np.array(0.105, requires_grad=True)
 
         var = circuit(n, a)
         expected = n ** 2 + n + np.abs(a) ** 2 * (1 + 2 * n)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -857,7 +857,7 @@ class TestProbability:
             return qml.var(op)
 
         n = np.array(0.12, requires_grad=True)
-        a = np.array(0.765,requires_grad=True)
+        a = np.array(0.765, requires_grad=True)
 
         var = circuit(n, a)
         expected = n ** 2 + n + np.abs(a) ** 2 * (1 + 2 * n)

--- a/tests/test_gaussian.py
+++ b/tests/test_gaussian.py
@@ -622,8 +622,8 @@ class TestVariance:
             qml.Displacement(a, 0, wires=0)
             return qml.var(qml.NumberOperator(0))
 
-        n = 0.12
-        a = 0.765
+        n = np.array(0.12, requires_grad=True)
+        a = np.array(0.765, requires_grad=True)
 
         var = circuit(n, a)
         expected = n ** 2 + n + np.abs(a) ** 2 * (1 + 2 * n)
@@ -830,8 +830,8 @@ class TestProbability:
             qml.Displacement(a, phi, wires=0)
             return qml.probs(wires=[0])
 
-        a = 0.4
-        phi = -0.12
+        a = np.array(0.4, requires_grad=True)
+        phi = np.array(-0.12, requires_grad=True)
 
         # construct tape
         circuit.construct([a, phi], {})
@@ -856,8 +856,8 @@ class TestProbability:
             qml.Displacement(a, 0, wires=0)
             return qml.var(op)
 
-        n = 0.12
-        a = 0.765
+        n = np.array(0.12, requires_grad=True)
+        a = np.array(0.765,requires_grad=True)
 
         var = circuit(n, a)
         expected = n ** 2 + n + np.abs(a) ** 2 * (1 + 2 * n)


### PR DESCRIPTION
Do to recent [refactor](https://github.com/PennyLaneAI/pennylane/commit/bc822b40d97c11fc59570f96d4280374cee639ac) of PennyLane, default behaviour of `requires_grad` some scalar values need to be explicitly set as autograd tensors, with `requires_grad=True`.
