### PR TITLE
Updated ReadTheDocs badge to new url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ PennyLane Strawberry Fields Plugin
     :alt: CodeFactor Grade
     :target: https://www.codefactor.io/repository/github/pennylaneai/pennylane-sf
 
-.. image:: https://img.shields.io/readthedocs/pennylane-sf.svg?logo=read-the-docs&style=flat-square
+.. image:: https://readthedocs.com/projects/xanaduai-pennylane-sf/badge/?version=latest&style=flat-square
     :alt: Read the Docs
-    :target: https://pennylane-sf.readthedocs.io
+    :target: https://docs.pennylane.ai/projects/strawberryfields
 
 .. image:: https://img.shields.io/pypi/v/PennyLane-sf.svg?style=flat-square
     :alt: PyPI


### PR DESCRIPTION
**Context:** New ReadTheDocs badge

**Description of the Change:**
The current RTD badge on the pennylane-qiskit README uses https://shield.io/, which unfortunately does not support the Business tier hosting of RTD.

The new solution is to use the badge that RTD themselves generate for each project.

This PR updates the RTD docs badge with the new links.

**Benefits:**
Old badge will go stale once the current community RTD builds are disabled. This new badge reflects the updated status.

**Possible Drawbacks:**
No logo available with the new badge

**Related GitHub Issues:**
None.