### PR TITLE
Convert list index to a tuple

### DIFF
--- a/pennylane_sf/remote.py
+++ b/pennylane_sf/remote.py
@@ -191,7 +191,7 @@ class StrawberryFieldsRemote(StrawberryFieldsSimulator):
                 else:
                     sl.append(slice(self.cutoff))
 
-            all_probs = fock_probs[sl]
+            all_probs = fock_probs[tuple(sl)]
         else:
             diff = self.cutoff - cutoff
             all_probs = np.pad(fock_probs, [(0, diff)] * self.num_wires)


### PR DESCRIPTION
With a newer version of NumPy, a list containing indices of a NumPy array may result in errors if the list was created using `slice` objects.

This PR converts the list to a tuple, which seems to work great even with newer NumPy versions.