### PR TITLE
remove python 3.7 support

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 * Remove python 3.7 support.
+  [(#129)](https://github.com/PennyLaneAI/pennylane-sf/pull/129)
 
 ### Improvements
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* Remove python 3.7 support.
+
 ### Improvements
 
 ### Documentation
@@ -13,6 +15,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Matthew Silverman
 
 ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10', '3.11']
+        python-version: [3.8, 3.9, '3.10']
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Build and install Plugin
         run: |

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Dependencies
 
 PennyLane-SF requires the following libraries be installed:
 
-* `Python <http://python.org/>`__ >=3.7
+* `Python <http://python.org/>`__ >=3.8
 
 as well as the following Python packages:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -45,7 +45,7 @@ Keras-Preprocessing==1.1.2
 lark-parser==0.12.0
 latexcodec==2.0.1
 libclang==14.0.1
-llvmlite==0.38.1
+llvmlite==0.39.1
 locket==1.0.0
 Markdown==3.3.7
 MarkupSafe==2.1.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -58,8 +58,8 @@ nbformat==5.4.0
 nbsphinx==0.8.9
 nest-asyncio==1.5.5
 networkx==2.8.4
-numba==0.55.2
-numpy==1.22.4
+numba==0.56.4
+numpy==1.23.5
 oauthlib==3.2.0
 opt-einsum==3.3.0
 packaging==21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,8 @@ locket==1.0.0
 mpmath==1.2.1
 networkx==2.8.4
 ninja==1.10.2.3
-numba==0.55.2
-numpy==1.22.4
+numba==0.56.4
+numpy==1.23.5
 packaging==21.3
 partd==1.2.0
 PennyLane==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ fsspec==2022.5.0
 future==0.18.2
 idna==3.3
 lark-parser==0.12.0
-llvmlite==0.38.1
+llvmlite==0.39.1
 locket==1.0.0
 mpmath==1.2.1
 networkx==2.8.4

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Locally, I did the following:

```bash
# test with minimum versions in setup.py
pip install pennylane==0.19.0 strawberryfields==0.22.0 tensorflow-macos pytest pytest-mock
pip install -r requirements.txt
pip install -e .
make test

# test with latest versions of unpinned libs (from requirements-ci.txt)
pip install pennylane==0.29.0 strawberryfields==0.23.0
make test
```

Both passed fine. Won't hard-pin anything to recent versions because they're all compatible! I can bump the pinned ones in `requirements.txt` if anyone wants.