### PR TITLE
Update warning to show better in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,11 +25,12 @@ PennyLane Strawberry Fields Plugin
     :alt: PyPI - Python Version
     :target: https://pypi.org/project/PennyLane-sf
 
-.. header-start-inclusion-marker-do-not-remove
+\
 
-.. warning::
-    This plugin will not be supported in newer versions of Pennylane. It is compatible with versions
-    of PennyLane up to and including 0.29.
+    **❗ This plugin will not be supported in newer versions of Pennylane. It is compatible with versions
+    of PennyLane up to and including 0.29❗**
+
+.. header-start-inclusion-marker-do-not-remove
 
 The PennyLane-SF plugin integrates the StrawberryFields photonic quantum computing framework with PennyLane's
 quantum machine learning capabilities.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,11 @@ PennyLane-Strawberry Fields Plugin
 
 :Release: |release|
 
+.. warning::
+
+    This plugin will not be supported in newer versions of Pennylane. It is compatible with versions
+    of PennyLane up to and including 0.29.
+
 .. include:: ../README.rst
   :start-after:	header-start-inclusion-marker-do-not-remove
   :end-before: header-end-inclusion-marker-do-not-remove


### PR DESCRIPTION
Now, the README warning shows more clearly: [before](https://github.com/PennyLaneAI/pennylane-sf/blob/master/README.rst) and [after](https://github.com/PennyLaneAI/pennylane-sf/blob/6cb15ab81cfa14320fdbc62e78b191ce6ea5bed8/README.rst).

Note that the [warning still shows in the docs page](https://xanaduai-pennylane--135.com.readthedocs.build/projects/strawberryfields/en/135/).

