### PR TITLE
Set version to v0.29.1

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,14 +1,9 @@
-# Release 0.30.0-dev
-
-### New features since last release
+# Release 29.1
 
 ### Breaking changes
 
-### Improvements
-
-### Documentation
-
-### Bug fixes
+* Pins package to working with PennyLane less than version 0.30.
+  [(#134)](https://github.com/PennyLaneAI/pennylane-sf/pull/134)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 29.1
+# Release 0.29.1
 
 ### Breaking changes
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,18 +4,16 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-  version: 3.8
-  install:
-    - requirements: ci_build_requirements.txt
-    - requirements: doc/requirements.txt
-    - method: pip
-      path: .
-  system_packages: true
+    version: 3.8
+    install:
+        - requirements: ci_build_requirements
+        - requirements: doc/requirements.txt
+        - method: pip
+          path: .
+    system_packages: true
 
 build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.8"
-  jobs:
-    pre_install:
-      - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt
+    image: latest
+    jobs:
+        pre_install:
+            - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,8 @@ python:
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "3.8"
   jobs:
     pre_install:
       - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,6 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-    version: 3.8
     install:
         - requirements: ci_build_requirements
         - requirements: doc/requirements.txt
@@ -14,6 +13,8 @@ python:
 
 build:
     image: latest
+    tools:
+        python: "3.8"
     jobs:
         pre_install:
             - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,6 @@ python:
 
 build:
     image: latest
-  jobs:
-    pre_install:
-      - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt
+    jobs:
+      pre_install:
+        - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,8 +14,6 @@ python:
 
 build:
   os: ubuntu-22.04
-  tools:
-    python: "3.8"
   jobs:
     pre_install:
       - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ python:
     system_packages: true
 
 build:
-    image: latest
+    os: ubuntu-22.04
     tools:
         python: "3.8"
     jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
 
 python:
     install:
-        - requirements: ci_build_requirements
+        - requirements: ci_build_requirements.txt
         - requirements: doc/requirements.txt
         - method: pip
           path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,16 +4,18 @@ sphinx:
   configuration: doc/conf.py
 
 python:
-    version: 3.8
-    install:
-        - requirements: ci_build_requirements.txt
-        - requirements: doc/requirements.txt
-        - method: pip
-          path: .
-    system_packages: true
+  version: 3.8
+  install:
+    - requirements: ci_build_requirements.txt
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .
+  system_packages: true
 
 build:
-    image: latest
-    jobs:
-      pre_install:
-        - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+  jobs:
+    pre_install:
+      - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,7 @@ sphinx:
 python:
     version: 3.8
     install:
+        - requirements: ci_build_requirements.txt
         - requirements: doc/requirements.txt
         - method: pip
           path: .
@@ -13,3 +14,6 @@ python:
 
 build:
     image: latest
+  jobs:
+    pre_install:
+      - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,8 +3,6 @@ pip
 appdirs
 autograd
 autoray
-jax==0.3.17
-jaxlib==0.3.15
 mistune==0.8.4
 m2r2
 numpy
@@ -18,18 +16,8 @@ sphinx==4.2; python_version == "3.10"
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2
-tensorflow==2.11.1; platform_machine == "x86_64"
-tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
 tensornetwork==0.3
 toml
-torch==1.9.0+cpu; sys_platform != "darwin" and python_version < "3.10"
-torchvision==0.10.0+cpu; sys_platform != "darwin" and python_version < "3.10"
-torch==1.9.0; sys_platform == "darwin" and python_version < "3.10"
-torchvision==0.10.0; sys_platform == "darwin" and python_version < "3.10"
-torch==1.13.1; sys_platform != "darwin" and python_version == "3.10"
-torchvision==0.12.0+cpu; sys_platform != "darwin" and python_version == "3.10"
-torch==1.13.1; sys_platform == "darwin" and python_version == "3.10"
-torchvision==0.12.0; sys_platform == "darwin" and python_version == "3.10"
 jinja2==3.0.3
 rustworkx==0.12.1
 networkx==2.6

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -68,7 +68,6 @@ parso==0.8.3
 partd==1.2.0
 pexpect==4.8.0
 pickleshare==0.7.5
-prompt-toolkit==3.0.29
 protobuf==3.19.5
 psutil==5.9.1
 ptyprocess==0.7.0
@@ -111,9 +110,6 @@ sympy==1.10.1
 tensorboard==2.9.1
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tensorflow==2.11.1
-tensorflow-estimator==2.9.0
-tensorflow-io-gcs-filesystem==0.26.0
 termcolor==1.1.0
 thewalrus==0.19.0
 tinycss2==1.1.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -77,7 +77,6 @@ pybtex==0.24.0
 pybtex-docutils==1.0.2
 pydantic==1.9.1
 Pygments==2.12.0
-pygments-github-lexers==0.0.5
 pyparsing==3.0.9
 pyrsistent==0.18.1
 python-dateutil==2.8.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,7 +21,7 @@ docutils==0.16
 entrypoints==0.4
 executing==0.8.3
 fastjsonschema==2.15.3
-fire==0.4.0
+fire==0.5.0
 flatbuffers==1.12
 fsspec==2022.5.0
 gast==0.4.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,125 +1,39 @@
-absl-py==1.1.0
-alabaster==0.7.12
-antlr4-python3-runtime==4.12.0
-appdirs==1.4.4
-asttokens==2.0.5
-astunparse==1.6.3
-attrs==21.4.0
-Babel==2.10.3
-backcall==0.2.0
-beautifulsoup4==4.11.1
-bleach==5.0.0
-cachetools==5.2.0
-certifi==2022.12.7
-charset-normalizer==2.0.12
-cloudpickle==2.1.0
-dask==2022.6.0
-debugpy==1.6.0
-decorator==5.1.1
-defusedxml==0.7.1
-docutils==0.16
-entrypoints==0.4
-executing==0.8.3
-fastjsonschema==2.15.3
-flatbuffers==1.12
-fsspec==2022.5.0
-gast==0.4.0
-google-auth==2.8.0
-google-auth-oauthlib==0.4.6
-google-pasta==0.2.0
-grpcio==1.47.0
-h5py==3.7.0
-idna==3.3
-imagesize==1.3.0
-ipykernel==6.15.0
-ipython==8.10.0
-jedi==0.18.1
-Jinja2==3.1.2
-jsonschema==4.6.0
-jupyter-client==7.3.4
-jupyter-core==4.11.2
-jupyterlab-pygments==0.2.2
-keras==2.9.0
-Keras-Preprocessing==1.1.2
-lark-parser==0.12.0
-latexcodec==2.0.1
-libclang==14.0.1
-llvmlite==0.39.1
-locket==1.0.0
-Markdown==3.3.7
-MarkupSafe==2.1.1
-matplotlib-inline==0.1.3
+--find-links https://download.pytorch.org/whl/torch_stable.html
+pip
+appdirs
+autograd
+autoray
+jax==0.3.17
+jaxlib==0.3.15
 mistune==0.8.4
-mpmath==1.2.1
-nbclient==0.6.4
-nbconvert==6.5.1
-nbformat==5.4.0
-nbsphinx==0.8.9
-nest-asyncio==1.5.5
-networkx==2.8.4
-numba==0.56.4
-numpy==1.23.5
-oauthlib==3.2.2
-opt-einsum==3.3.0
-packaging==21.3
-pandocfilters==1.5.0
-parso==0.8.3
-partd==1.2.0
-pexpect==4.8.0
-pickleshare==0.7.5
-protobuf==3.19.5
-psutil==5.9.1
-ptyprocess==0.7.0
-pure-eval==0.2.2
-pyasn1==0.4.8
-pyasn1-modules==0.2.8
-pybtex==0.24.0
-pybtex-docutils==1.0.2
-pydantic==1.9.1
-Pygments==2.12.0
-pyparsing==3.0.9
-pyrsistent==0.18.1
-python-dateutil==2.8.2
-python-dotenv==0.20.0
-pytz==2022.1
-PyYAML==6.0
-pyzmq==23.2.0
-quantum-blackbird==0.4.0
-quantum-xir==0.2.1
-requests==2.28.0
-requests-oauthlib==1.3.1
-rsa==4.8
-scipy==1.8.1
-six==1.16.0
-snowballstemmer==2.2.0
-soupsieve==2.3.2.post1
-Sphinx==5.0.2
-sphinx-automodapi==0.14.1
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-bibtex==2.4.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.0
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
-stack-data==0.3.0
+m2r2
+numpy
+pygments-github-lexers
+semantic_version==2.10
+scipy
+docutils==0.16
 StrawberryFields==0.23.0
-sympy==1.10.1
-tensorboard==2.9.1
-tensorboard-data-server==0.6.1
-tensorboard-plugin-wit==1.8.1
-termcolor==1.1.0
-thewalrus==0.19.0
-tinycss2==1.1.1
-toml==0.10.2
-toolz==0.11.2
-tornado==6.1
-traitlets==5.3.0
-typing_extensions==4.2.0
-urllib3==1.26.9
-wcwidth==0.2.5
-webencodings==0.5.1
-Werkzeug==2.2.3
-wrapt==1.14.1
-xanadu-cloud-client==0.2.1
+sphinx==3.5; python_version < "3.10"
+sphinx==4.2; python_version == "3.10"
+sphinx-automodapi==0.13
+sphinx-copybutton
+sphinxcontrib-bibtex==2.4.2
+tensorflow==2.11.1; platform_machine == "x86_64"
+tensorflow_macos==2.9.0; sys_platform == "darwin" and platform_machine == "arm64"
+tensornetwork==0.3
+toml
+torch==1.9.0+cpu; sys_platform != "darwin" and python_version < "3.10"
+torchvision==0.10.0+cpu; sys_platform != "darwin" and python_version < "3.10"
+torch==1.9.0; sys_platform == "darwin" and python_version < "3.10"
+torchvision==0.10.0; sys_platform == "darwin" and python_version < "3.10"
+torch==1.13.1; sys_platform != "darwin" and python_version == "3.10"
+torchvision==0.12.0+cpu; sys_platform != "darwin" and python_version == "3.10"
+torch==1.13.1; sys_platform == "darwin" and python_version == "3.10"
+torchvision==0.12.0; sys_platform == "darwin" and python_version == "3.10"
+jinja2==3.0.3
+rustworkx==0.12.1
+networkx==2.6
+requests~=2.28.1
+# we do not pin the sphinx theme, to allow the
+# navbar and header data to be updated at the source
 pennylane-sphinx-theme

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,7 +21,6 @@ docutils==0.16
 entrypoints==0.4
 executing==0.8.3
 fastjsonschema==2.15.3
-fire==0.5.0
 flatbuffers==1.12
 fsspec==2022.5.0
 gast==0.4.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 absl-py==1.1.0
 alabaster==0.7.12
-antlr4-python3-runtime==4.8
+antlr4-python3-runtime==4.12.0
 appdirs==1.4.4
 asttokens==2.0.5
 astunparse==1.6.3

--- a/pennylane_sf/_version.py
+++ b/pennylane_sf/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.30.0-dev"
+__version__ = "0.29.1"


### PR DESCRIPTION
We will be making one final release of pennylane-sf in order to pin the version on pypi to `pennylane<v0.30.0`.