### PR TITLE
Update tutorial image links

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
 
 python:
     install:
-        - requirements: ci_build_requirements.txt
+        - requirements: requirements-ci.txt
         - requirements: doc/requirements.txt
         - method: pip
           path: .
@@ -17,4 +17,4 @@ build:
         python: "3.8"
     jobs:
         pre_install:
-            - echo "setuptools~=66.0\npip~=22.0" >> ci_build_requirements.txt
+            - echo "setuptools~=66.0\npip~=22.0" >> requirements-ci.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,6 @@ python:
         - requirements: doc/requirements.txt
         - method: pip
           path: .
-    system_packages: true
 
 build:
     os: ubuntu-22.04

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -75,17 +75,17 @@ Check out these demos to see the PennyLane-SF plugin in action:
 
 .. title-card::
     :name: Plugins and Hybrid computation
-    :description: <img src="https://pennylane.ai/_images/photon_redirection.png" width="100%"/>
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/plugins_hybrid/photon_redirection.png" width="100%"/>
     :link: https://pennylane.ai/qml/demos/plugins_hybrid.html
 
 .. title-card::
     :name: Function fitting with a photonic quantum neural network
-    :description: <img src="https://pennylane.ai/_images/qnn_output_28_0.png" width="100%"/>
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/quantum_neural_net/qnn_output_28_0.png" width="100%"/>
     :link: https://pennylane.ai/qml/demos/quantum_neural_net.html
 
 .. title-card::
     :name: Quantum advantage with Gaussian Boson Sampling
-    :description: <img src="https://pennylane.ai/_images/gbs_thumbnail.png" width="100%"/>
+    :description: <img src="https://pennylane.ai/_static/demonstration_assets/gbs/gbs_thumbnail.png" width="100%"/>
     :link: https://pennylane.ai/qml/demos/gbs.html
 
 .. raw:: html

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,3 @@
 strawberryfields
 pennylane<0.30
-tensorflow
+tensorflow<2.13


### PR DESCRIPTION
Image links pointed to old locations in the QML repo and one was broken:
![image](https://github.com/PennyLaneAI/pennylane-sf/assets/12532113/d6b56ce7-8b0c-468e-bdb9-e342fb6a47c3)

This PR fixes these links to point to the right locations