### PR TITLE
SC80141 | Fix ReadTheDocs Build

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,14 @@
 name: Formatting check
 on:
-- pull_request
+  pull_request:
+    paths:
+      - pennylane_sf/**
+      - tests/**
+      - .pylintrc
+      - Makefile
+      - requirements-ci.txt
+      - requirements.txt
+      - setup.py
 
 jobs:
   black:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,14 @@ on:
     branches:
       - master
   pull_request:
+    paths:
+      - pennylane_sf/**
+      - tests/**
+      - .pylintrc
+      - Makefile
+      - requirements-ci.txt
+      - requirements.txt
+      - setup.py
 
 jobs:
   tests:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,19 +1,17 @@
 version: 2
 
 sphinx:
-    configuration: doc/conf.py
+  configuration: doc/conf.py
 
 python:
-    install:
-        - requirements: requirements-ci.txt
-        - requirements: doc/requirements.txt
-        - method: pip
-        path: .
+  install:
+    - requirements: doc/requirements.txt
+    - method: pip
+      path: .
 
 build:
-    os: ubuntu-22.04
-    tools:
-        python: "3.8"
-    jobs:
-        pre_install:
-            - echo "setuptools~=66.0\npip~=22.0" >> requirements-ci.txt
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+  apt_packages:
+    - graphviz

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.9"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,4 +12,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,14 @@
 version: 2
 
 sphinx:
-  configuration: doc/conf.py
+    configuration: doc/conf.py
 
 python:
     install:
         - requirements: requirements-ci.txt
         - requirements: doc/requirements.txt
         - method: pip
-          path: .
+        path: .
 
 build:
     os: ubuntu-22.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,3 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
-  apt_packages:
-    - graphviz

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,6 +16,7 @@ sphinx==4.2; python_version == "3.10"
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,6 +13,7 @@ docutils==0.16
 StrawberryFields==0.23.0
 sphinx==3.5; python_version < "3.10"
 sphinx==4.2; python_version == "3.10"
+sphinxcontrib-applehelp==1.0.4
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,6 +14,7 @@ StrawberryFields==0.23.0
 sphinx==3.5; python_version < "3.10"
 sphinx==4.2; python_version == "3.10"
 sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,6 +16,7 @@ sphinx==4.2; python_version == "3.10"
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinx-automodapi==0.13
 sphinx-copybutton

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -15,6 +15,7 @@ sphinx==3.5; python_version < "3.10"
 sphinx==4.2; python_version == "3.10"
 sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
 sphinx-automodapi==0.13
 sphinx-copybutton
 sphinxcontrib-bibtex==2.4.2


### PR DESCRIPTION
**Description of the Change:**
- https://app.shortcut.com/xanaduai/story/80141/fix-readthedocs-build-for-xanaduai-pennylane-sf
- Update `sphinxcontrib-applehelp`, `sphinxcontrib-bibtex`, `sphinxcontrib-devhelp`, `sphinxcontrib-htmlhelp`, `sphinxcontrib-qthelp`, and `sphinxcontrib-serializinghtml` versions to work with the version of sphinx used for docs
- Bump python version in `.readthedocs.yml` to `3.9`

**Benefits:**
RTD builds without errors, and the navbar from pennylane.ai (see https://xanaduai-pennylane--152.com.readthedocs.build/projects/strawberryfields/en/152/)

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A