### PR TITLE
Update ubuntu version to 24.04 in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ python:
       path: .
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"


### PR DESCRIPTION
**Description of the Change:**
Upgrading the readthedocs.yml runner to Ubuntu-24.04 from Ubuntu22.04; 22.04 is in end of life.

**Benefits:**
The readthedocs runner gets upgrade.

**Possible Drawbacks:**
There could be potential compatibility issues with sphinx and other packages. None were found in the PR run.

**Related GitHub Issues:**
